### PR TITLE
scan fonts inside this node only

### DIFF
--- a/Zho_TextImage.py
+++ b/Zho_TextImage.py
@@ -127,7 +127,7 @@ class Text_Image_Zho:
         fonts = []
 
         for extension in font_extensions:
-            fonts.extend(comfy_dir.glob(f"**/{extension}"))
+            fonts.extend(here.glob(f"**/{extension}"))
 
         if not fonts:
             log.warn(
@@ -335,7 +335,7 @@ class Text_Image_Multiline_Zho:
         fonts = []
 
         for extension in font_extensions:
-            fonts.extend(comfy_dir.glob(f"**/{extension}"))
+            fonts.extend(here.glob(f"**/{extension}"))
 
         if not fonts:
             log.warn(

--- a/Zho_TextImage_frame.py
+++ b/Zho_TextImage_frame.py
@@ -126,7 +126,7 @@ class Text_Image_Frame_Zho:
         fonts = []
 
         for extension in font_extensions:
-            fonts.extend(comfy_dir.glob(f"**/{extension}"))
+            fonts.extend(here.glob(f"**/{extension}"))
 
         if not fonts:
             log.warn(


### PR DESCRIPTION
Scan the whole comfyui dir is taking too mush time(more than 1 minute) since i've installed a lot of nodes.

When comfyui starts, the first time launch the web ui, it will get objects info for all nodes by the api /object_info, and it will call INPUT_TYPES() from each node, this will cost more than 1 minute.

Let's scan fonts inside this node only. 

And I think this pull request fixed #3 